### PR TITLE
Add templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,27 @@
+---
+name: "\U0001F41B Bug"
+about: "Something isn't right."
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+## Bug
+#### Current Behavior
+A clear and concise description of what is happening
+
+#### Steps to Reproduce
+Code, command line, or other relevant input.
+
+```
+```
+
+#### Expected Behavior
+A clear and concise description of what you expect to happen.
+
+#### Possible Solutions
+Any links or ideas that you've already identified related to solving this bug.
+
+#### Related Issues
+A list of related issues

--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,0 +1,16 @@
+---
+name: "\U0001F4AC Discussion"
+about: "I want to discuss a question or concept."
+title: ''
+labels: 'discussion'
+assignees: ''
+
+---
+
+## Discussion
+
+#### What do you want to talk about?
+A clear and concise description of the discussion you want, and why you want it.
+
+#### Relevant Resources / Research
+A list of anything you think someone should look at in order to engage.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,21 @@
+---
+name: "\U00002692 Team Task"
+about: "Something needs doing."
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Task
+
+#### Description
+A clear and concise description of what needs to be done
+
+{ - Related: #X }
+
+#### Relevant Resources / Research
+Any links or ideas that you've already collected related to the task
+
+#### Related Issues
+A list of related issues

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,20 @@
+## Description
+{ This PR adds ... }
+
+{ This PR fixes ... }
+
+{ This PR removes ... }
+
+{ Resolves {X}}
+
+{ Related to {Y}}
+
+## Steps to Test
+- { `yarn test` }
+- { Specific instructions }
+
+## Deploy Notes
+- { `yarn install` }
+- { `yarn migrate` }
+- { Populate environment variables ... }
+- { Set up ... }


### PR DESCRIPTION
## Description
This PR adds [issue](https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository) and [PR templates](https://docs.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository) to the organization.  These will be used by any repository in the org, but can be overridden in any given repo.

## Due Diligence Checklist
- [x] Consolidated commits

## Related Issues
Resolves #1 
